### PR TITLE
Allow user choose first source on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ JEST by Facebook was used to test the following parts of the code.
 - newsAPI.js
 - newsStore.js
 
-##Contributing
+## Contributing
 You are very welcome to grow this project and make it even more useful and complete. 
 To participate, simply fork or clone the project and make your pull requests on features you'd like to see.
 

--- a/src/js/components/Sources.jsx
+++ b/src/js/components/Sources.jsx
@@ -63,9 +63,6 @@ export default class Sources extends React.Component {
     this.setState({
       sources: newsStore.fetchSources(),
     });
-    if (this.state.sources.length > 0) {
-      this.reloadArticles(false);
-    }
   }
 
   /**
@@ -132,23 +129,26 @@ export default class Sources extends React.Component {
       ));
     return (
       <div>
-        <div className="ui center aligned text">
-          Select Filter
+        <div
+          className="ui right aligned container text" style={{ margin: '20px' }}
+        >
+          <Dropdown
+            placeholder="News Sources"
+            fluid search selection options={newsSources}
+            style={{ float: 'left', width: '60%' }}
+            onChange={(syntheticEvent, payload) => {
+              this.reloadArticles(false, payload.value);
+            }}
+          />
           <select
             id="filterSelector" className="ui search dropdown right floated"
+            style={{ width: '20%' }}
             onChange={() => {
               this.reloadArticles(true, this.currentSource);
             }}
           >
             {filterComponents}
           </select>
-          <Dropdown
-            placeholder="News Sources"
-            search selection options={newsSources}
-            onChange={(syntheticEvent, payload) => {
-              this.reloadArticles(false, payload.value);
-            }}
-          />
         </div>
       </div>
     );


### PR DESCRIPTION
#### What does this PR do?
This PR integrates into the project the search feature requested by the product owner.
#### Description of Task to be completed?
This feature allows the user to choose the first news source that has its articles populated on page load
#### How should this be manually tested?
Load up the project as described in the project README and then launch it on your browser.
On sign-in and loading of the `main` page, you'd notice no sources are automatically selected and no articles automatically get loaded to the page. This only happens after the user has explicitly made the selection.
#### Any background context you want to provide?
Previous functionality had the `sources`dropdown autoloading the first source in the project by default.
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A